### PR TITLE
Add auditing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bower_components/
 dist/
 midas_*.conf
 testing.db
+development.db
 
 # vim swap files
 .*.sw?

--- a/app/lib/MIDAS.pm
+++ b/app/lib/MIDAS.pm
@@ -59,6 +59,14 @@ __PACKAGE__->config(
   # DON'T send X-Catalyst header
   enable_catalyst_header => 0,
 
+  # configure audit logging
+  audit_log => {
+    dir    => '/var/log',
+    prefix => 'midas',
+    suffix => '.log',
+    size   => 10 * 1024 * 1024,    # 10Mb
+  },
+
   #-----------------------------------------------------------------------------
   # models
 

--- a/app/lib/MIDAS/ActionRole/NeedsAuth.pm
+++ b/app/lib/MIDAS/ActionRole/NeedsAuth.pm
@@ -64,7 +64,7 @@ has '_audit_log_config' => (
 # this point. The workaround is to set an attribute on the role every time we
 # need to write a log message, so that we can then lazily instantiate the log
 # writer.
-has '_log' => (
+has '_audit_logger' => (
   is      => 'ro',
   lazy    => 1,
   default => sub {
@@ -246,11 +246,7 @@ around execute => sub {
 
 =head2 _log_request($c, @user_details)
 
-Write an audit log for the request. The log message looks like:
-
- <UTC date/time> <semi-colon concatenated user_details>;<user IP address>;<HTTP method>;<URI>
-
-The user details are currently:
+Write an audit log entry for the request. The fields are:
 
 =over
 
@@ -259,6 +255,12 @@ The user details are currently:
 =item email address
 
 =item request method, either C<browser> or C<REST>
+
+=item user IP address
+
+=item HTTP method, e.g. GET or POST
+
+=item requested URI
 
 =back
 
@@ -283,7 +285,7 @@ sub _log_request {
   $self->_audit_log_config($c->config->{audit_log});
 
   try {
-    $self->_log->write("$log_string\n");
+    $self->_audit_logger->write("$log_string\n");
   }
   catch {
     $c->log->error( "failed to write log message: $_" );

--- a/app/t/audit_logging.t
+++ b/app/t/audit_logging.t
@@ -1,0 +1,70 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+use File::Path qw( make_path remove_tree );
+use File::Slurp;
+use HTTP::Request::Common;
+
+BEGIN {
+  $ENV{MIDAS_CONFIG}                 = 't/data/testing.conf';
+  $ENV{CATALYST_CONFIG_LOCAL_SUFFIX} = 'audit';
+}
+
+use Catalyst::Test 'MIDAS';
+
+# the DSN here has to match that specified in "testing_audit.conf"
+use Test::DBIx::Class {
+  connect_info => [ 'dbi:SQLite:dbname=testing.db', '', '' ],
+}, qw( :resultsets );
+
+# load the pre-requisite data
+fixtures_ok 'main', 'installed fixtures';
+
+my $tmp_dir = '/tmp/__midas_audit_logs';
+remove_tree( $tmp_dir );
+make_path( $tmp_dir );
+
+my $log_file = "$tmp_dir/midas.log";
+
+# check there's no log file before we start
+ok ! -f $log_file, 'no audit log at start';
+
+# make a valid request and make sure there's a log file afterwards
+my @request_params = (
+  GET '/samples',
+  Authorization => 'testuser:2566ZD3k4SVdJfGkdXJQUj6B4aPoq2Rf',
+  Content_Type  => 'application/json',
+);
+my $res = request(@request_params);
+is $res->status_line, '200 OK', 'got 200 with valid user and API key';
+
+ok -f $log_file, 'found audit log';
+
+my @log_file_contents = read_file $log_file;
+
+is scalar @log_file_contents, 1, 'found one line in log file';
+like $log_file_contents[0], qr|testuser;testuser\@sanger\.ac\.uk;REST;127\.0\.0\.1;GET;http://localhost/samples|, 'log file looks correct';
+
+# add lots of log messages; should trigger a logrotate, leaving 6 rows in rotated
+# file and 5 in active log
+request(@request_params) foreach ( 1 .. 10 );
+
+my @log_files = read_dir $tmp_dir;
+is scalar @log_files, 2, 'found active and rotated logs';
+
+@log_file_contents = read_file "$tmp_dir/$log_files[0]";
+is scalar @log_file_contents, 5, 'found 5 rows in active log';
+
+@log_file_contents = read_file "$tmp_dir/$log_files[1]";
+is scalar @log_file_contents, 6, 'found 6 rows in rotated log';
+
+$DB::single = 1;
+
+done_testing;
+
+remove_tree( $tmp_dir );
+

--- a/app/t/data/testing_audit.conf
+++ b/app/t/data/testing_audit.conf
@@ -1,0 +1,16 @@
+# testing_audit.conf
+# jt6 20150508 WTSI
+#
+# this is a configuration file used by t/audit_logging.t
+
+<audit_log>
+  dir   /tmp/__midas_audit_logs
+  size  512 # bytes
+</audit_log>
+
+<Model::HICFDB>
+  <connect_info>
+    dsn  dbi:SQLite:dbname=testing.db
+  </connect_info>
+</Model::HICFDB>
+

--- a/app/t/etc/audit_logging.pl
+++ b/app/t/etc/audit_logging.pl
@@ -1,0 +1,15 @@
+# database definition used by t/audit_logging.t
+{
+  schema_class => 'Bio::HICF::Schema',
+  resultsets => [ qw(
+    User
+  ) ],
+  fixture_sets => {
+    main => [
+      User => [
+        [ qw( username passphrase displayname email roles api_key ) ],
+        [ 'testuser', 'password', 'Test User', 'testuser@sanger.ac.uk', 'user', '2566ZD3k4SVdJfGkdXJQUj6B4aPoq2Rf' ],
+      ],
+    ],
+  },
+};


### PR DESCRIPTION
This branch fleshes out the handling of audit logs. Log entries are now written to an audit log file, which is rotated when its size exceeds a configurable limit.