### PR TITLE
Improve display of sample data

### DIFF
--- a/app/lib/MIDAS.pm
+++ b/app/lib/MIDAS.pm
@@ -103,6 +103,7 @@ __PACKAGE__->config(
 
   'Controller::Login' => {
     traits => ['-RenderAsTTTemplate'],
+    redirect_after_login_uri => '/summary',
   },
 
   'Controller::Validation' => {

--- a/app/lib/MIDAS/Base/Controller/Restful.pm
+++ b/app/lib/MIDAS/Base/Controller/Restful.pm
@@ -6,9 +6,24 @@ use namespace::autoclean;
 
 use Text::CSV_XS;
 
-BEGIN { extends 'Catalyst::Controller::REST' }
+BEGIN { extends 'Catalyst::Controller::REST'; }
+
+=head1 NAME
+
+MIDAS::Base::Controller::Resful - base class to set up serialisation for REST
+
+=head1 DESCRIPTION
+
+This is a base class for controllers implementing RESTful endpoints. It provides
+methods to serialise data in CSV, which are required in order to handle AMR
+data properly.
+
+=cut
 
 #-------------------------------------------------------------------------------
+
+# set up Catalyst::Controller::REST. The main item here is the addition of the
+# callback for "text/csv", which points to the bespoke method here
 
 __PACKAGE__->config(
   default   => 'text/html',
@@ -24,6 +39,12 @@ __PACKAGE__->config(
 );
 
 #-------------------------------------------------------------------------------
+#- attributes ------------------------------------------------------------------
+#-------------------------------------------------------------------------------
+
+=head1 ATTRIBUTES
+
+=cut
 
 # an instance of Text::CSV_XS, used for rendering CSV output
 has '_csv' => (
@@ -32,26 +53,56 @@ has '_csv' => (
   default => sub { Text::CSV_XS->new; },
 );
 
+=head2 returned_columns
+
+Read-only attribute that stores a reference to an array containing the list of
+columns that will be returned by "_render_csv".
+
+=cut
+
+has 'returned_columns' => (
+  is      => 'ro',
+  default => sub {
+    [ qw(
+      sample_id
+      manifest_id
+      raw_data_accession
+      sample_accession
+      sample_description
+      collected_at
+      tax_id
+      scientific_name
+      collected_by
+      source
+      collection_date
+      location
+      host_associated
+      specific_host
+      host_disease_status
+      host_isolation_source
+      patient_location
+      isolation_source
+      serovar
+      other_classification
+      strain
+      isolate
+    ) ];
+  }
+);
+
+#-------------------------------------------------------------------------------
+#- private methods -------------------------------------------------------------
 #-------------------------------------------------------------------------------
 
 # callback to render a data structure as CSV
 sub _render_csv {
   my ( $data, $controller, $c ) = @_;
 
-  my @keys;
-
-  # which fields should be returned in the CSV?
-  if ( $controller->returned_columns ) {
-    # use the fields that the controller says it will return
-    @keys = @{ $controller->returned_columns };
-  }
-  else {
-    # use all fields in the dataset, and return them in sort order
-    @keys = sort keys %{ $data->[0] };
-  }
+  # use the fields that the controller says it will return
+  my @keys = @{ $controller->returned_columns };
 
   # build a header row
-  my $status = $controller->_csv->combine(@keys);
+  my $status = $controller->_csv->combine(@keys, 'amr');
   die 'problem generating CSV header' unless $status;
 
   my @output = ( $controller->_csv->string );
@@ -60,8 +111,7 @@ sub _render_csv {
   foreach my $row ( @$data ) {
 
     my @values = map { $row->{$_} } @{ $controller->returned_columns };
-
-    # TODO format AMR data as a string and add it to the output
+    push @values, _format_amr($row->{amr});
 
     $status = $controller->_csv->combine(@values);
     die 'problem generating CSV' unless $status;
@@ -70,6 +120,27 @@ sub _render_csv {
   }
 
   return join "\n", @output;
+}
+
+#-------------------------------------------------------------------------------
+
+# formats the antimicrobial resistance test results for the given row
+sub _format_amr {
+  my ( $amrs ) = shift;
+
+  my @amrs = ();
+  foreach my $amr ( @$amrs ) {
+    my $amr_string .= $amr->{antimicrobial_name} . ';'
+                   .  $amr->{susceptibility} . ';'
+                   .  ( $amr->{equality} eq 'eq' ? '' : $amr->{equality} )
+                   .  $amr->{mic};
+
+    $amr_string .= ';' . $amr->{diagnostic_centre} if $amr->{diagnostic_centre};
+
+    push @amrs, $amr_string;
+  }
+
+  return join ',', @amrs;
 }
 
 #-------------------------------------------------------------------------------

--- a/app/lib/MIDAS/Base/Controller/Restful.pm
+++ b/app/lib/MIDAS/Base/Controller/Restful.pm
@@ -4,6 +4,8 @@ package MIDAS::Base::Controller::Restful;
 use Moose;
 use namespace::autoclean;
 
+use Text::CSV_XS;
+
 BEGIN { extends 'Catalyst::Controller::REST' }
 
 #-------------------------------------------------------------------------------
@@ -16,8 +18,57 @@ __PACKAGE__->config(
     'text/yaml'          => 'YAML',
     'text/x-yaml'        => 'YAML',
     'application/x-yaml' => 'YAML',
+    'text/csv'           => [ 'Callback', { serialize => \&_render_csv } ],
   }
 );
+
+#-------------------------------------------------------------------------------
+
+# an instance of Text::CSV_XS, used for rendering CSV output
+has '_csv' => (
+  is      => 'ro',
+  lazy    => 1,
+  default => sub { Text::CSV_XS->new; },
+);
+
+#-------------------------------------------------------------------------------
+
+# callback to render a data structure as CSV
+sub _render_csv {
+  my ( $data, $controller, $c ) = @_;
+
+  my @keys;
+
+  # which fields should be returned in the CSV?
+  if ( $controller->returned_columns ) {
+    # use the fields that the controller says it will return
+    @keys = @{ $controller->returned_columns };
+  }
+  else {
+    # use all fields in the dataset, and return them in sort order
+    @keys = sort keys %{ $data->[0] };
+  }
+
+  # build a header row
+  my $status = $controller->_csv->combine(@keys);
+  die 'problem generating CSV header' unless $status;
+
+  my @output = ( $controller->_csv->string );
+
+  # it's a bit ugly, but we just walk the array and dump each row in turn
+  foreach my $row ( @$data ) {
+    my @values = ();
+    foreach my $key ( @keys ) {
+      push @values, $row->{$key};
+    }
+    $status = $controller->_csv->combine(@values);
+    die 'problem generating CSV' unless $status;
+
+    push @output, $controller->_csv->string;
+  }
+
+  return join "\n", @output;
+}
 
 #-------------------------------------------------------------------------------
 

--- a/app/lib/MIDAS/Base/Controller/Restful.pm
+++ b/app/lib/MIDAS/Base/Controller/Restful.pm
@@ -11,8 +11,9 @@ BEGIN { extends 'Catalyst::Controller::REST' }
 #-------------------------------------------------------------------------------
 
 __PACKAGE__->config(
-  default => 'text/html',
-  map     => {
+  default   => 'text/html',
+  stash_key => 'output',
+  map       => {
     'text/html'          => [ 'View', 'HTML' ],
     'application/json'   => 'JSON',
     'text/yaml'          => 'YAML',
@@ -57,10 +58,11 @@ sub _render_csv {
 
   # it's a bit ugly, but we just walk the array and dump each row in turn
   foreach my $row ( @$data ) {
-    my @values = ();
-    foreach my $key ( @keys ) {
-      push @values, $row->{$key};
-    }
+
+    my @values = map { $row->{$_} } @{ $controller->returned_columns };
+
+    # TODO format AMR data as a string and add it to the output
+
     $status = $controller->_csv->combine(@values);
     die 'problem generating CSV' unless $status;
 

--- a/app/lib/MIDAS/Controller/Manifest.pm
+++ b/app/lib/MIDAS/Controller/Manifest.pm
@@ -4,7 +4,7 @@ package MIDAS::Controller::Manifest;
 use Moose;
 use namespace::autoclean;
 
-BEGIN { extends 'MIDAS::Base::Controller::Restful' }
+BEGIN { extends 'MIDAS::Base::Controller::Restful'; }
 
 =head1 NAME
 

--- a/app/root/static/javascripts/samples.js
+++ b/app/root/static/javascripts/samples.js
@@ -9,10 +9,47 @@ var samples = (function() {
 
   return {
 
-    // add listeners where needed
+    // build the contents of the row showing AMR data for a sample
+    _formatAMR: function(d) {
+      /*jshint camelcase: false */
+      var table = [],
+          equality,
+          susceptibilityClass;
+      table.push( "<table class='amrData table table-striped table-condensed'>" );
+      table.push( "<thead><tr>" );
+      table.push( "<th>Compound name</th>" );
+      table.push( "<th><abbr title='Susceptible (S), Intermediate (I), Resistant (R)'>Susceptibility</abbr></th>" );
+      table.push( "<th><abbr title='Minimum Inhibitory Concentration'>MIC</abbr> (<abbr title='milligrammes per litre'>mg/l</abbr>)</th>" );
+      table.push( "</tr></thead>" );
+      table.push( "<tbody>" );
+      $.each( d[d.length - 1], function(i, amr) {
+        switch ( amr.susceptibility ) {
+          case "S": susceptibilityClass = "amrS"; break;
+          case "I": susceptibilityClass = "amrI"; break;
+          case "R": susceptibilityClass = "amrR";  break;
+        }
+        table.push( "<tr class='" + susceptibilityClass + "'>" );
+        table.push( "<td class='amrName'>" + amr.antimicrobial_name + "</td>" );
+        table.push( "<td class='amrSIR'>"  + amr.susceptibility + "</td>" );
+        switch ( amr.equality ) {
+          case "le": equality = "&le;"; break;
+          case "lt": equality = "&lt;"; break;
+          case "eq": equality = "";     break;
+          case "gt": equality = "&gt;"; break;
+          case "ge": equality = "&ge;"; break;
+        }
+        table.push( "<td class='amrMIC'>" + equality + amr.mic + "</td>" );
+        table.push( "</tr>" );
+      } );
+      table.push( "</tbody></table>" );
+
+      return table.join("");
+    },
+
+    // set up the samples table
     setupTable: function() {
 
-      $("#samples").dataTable( {
+      var samplesTable = $("#samples").DataTable( {
         // dom: "T<'clear'>lfrtip",
         serverSide: true,
         ajax: {
@@ -21,12 +58,74 @@ var samples = (function() {
             // add a param to signify that this request comes from DataTables
             d._dt = 1;
           }
+        },
+        columns: [
+          {
+            // targets: 0,
+            render: function(data, type, row, meta) {
+              return "<a href='/sample/" + data + "'>" + data + "</a>";
+            }
+          },
+          null,
+          {
+            // targets: 2,
+            orderData: 2,
+            render: function(data, type, row, meta) {
+              return row[2] + " (" + row[3] + ")";
+            }
+          },
+          {
+            visible: false
+          },
+          null,
+          null,
+          {
+            // targets: 6,
+            className: "amrCell text-center",
+            orderable: false,
+            render: function(data, type, row, meta) {
+              if ( Object.keys(data).length > 0 ) {
+                return "<i title='Sample has AMR data' class='hasAMR fa fa-plus-square'></i>";
+              } else {
+                return "<i title='No AMR data for sample' class='noAMR fa fa-times'></i>";
+              }
+              // return data;
+            }
+          }
+        ]
+      } );
+
+      // add a listener to show AMR data for samples that possess it
+      $("#samples tbody").on("click", "td.amrCell", function() {
+        var tr,
+            row,
+            hasAMR = $(this).children(".hasAMR");
+
+        if ( hasAMR.length < 1 ) {
+          return;
+        }
+
+        tr  = $(this).closest("tr");
+        row = samplesTable.row(tr);
+
+        if ( row.child.isShown() ) {
+          row.child.hide();
+          tr.removeClass("shown");
+          hasAMR.removeClass("fa-minus-square")
+                .addClass("fa-plus-square");
+        } else {
+          row.child( samples._formatAMR( row.data() ) ).show();
+          tr.addClass("shown");
+          hasAMR.removeClass("fa-plus-square")
+                .addClass("fa-minus-square");
         }
       } );
 
+      // listen for changes to the "search" input that filters the table and show/hide
+      // the text in the "Download data" label
       $("#samples_filter input").on("input change", function(e) {
         var filterTerm = $(e.target).val();
-        if ( filterTerm === undefined || filterTerm == "" ) {
+        if ( filterTerm === undefined || filterTerm === "" ) {
           $("#filtered").hide();
           $("#all").show();
         } else {
@@ -35,13 +134,15 @@ var samples = (function() {
         }
       } );
 
+      // listen for clicks on the download buttons. If there's a click, we build the
+      // URL to download the specified format, then tell the browser to retrieve it
       $("button.table-download-link").on("click", function(e) {
         var filterTerm = $("#samples_filter input").val(),
             dlFormat   = e.target.dataset.format,
             dlURL      = window.location.href;
         dlURL += "?dl=1";
         dlURL += "&content-type=" + encodeURIComponent(dlFormat);
-        if ( filterTerm !== undefined && filterTerm != "" ) {
+        if ( filterTerm !== undefined && filterTerm !== "" ) {
           dlURL += "&filter=" + encodeURIComponent(filterTerm);
         }
         console.debug( "redirecting to " + dlURL );

--- a/app/root/static/javascripts/samples.js
+++ b/app/root/static/javascripts/samples.js
@@ -54,9 +54,11 @@ var samples = (function() {
     setupTable: function() {
       /*jshint camelcase: false */
 
-      var samplesTable = $("#samples").DataTable( {
+      var samplesTable = $("#samples-table").DataTable( {
         // dom: "T<'clear'>lfrtip",
         serverSide: true,
+        stateSave: true,
+        stateDuration: -1,
         ajax: {
           url: window.location.href,
           data: function(d) {
@@ -70,6 +72,18 @@ var samples = (function() {
             render: function(data, type, row, meta) {
               return "<a href='/sample/" + row.sample_id + "'>" +
                      row.sample_id + "</a>";
+            }
+          },
+          {
+            // AMR data
+            className: "amrCell text-center",
+            orderable: false,
+            render: function(data, type, row, meta) {
+              if ( Object.keys(row.amr).length > 0 ) {
+                return "<i title='Sample has AMR data' class='hasAMR fa fa-plus-square'></i>";
+              } else {
+                return "<i title='No AMR data for sample' class='noAMR fa fa-times'></i>";
+              }
             }
           },
           {
@@ -119,19 +133,7 @@ var samples = (function() {
           { data: "serovar" },
           { data: "other_classification",   visible: false },
           { data: "strain" },
-          { data: "isolate",                visible: false },
-          {
-            // AMR data
-            className: "amrCell text-center",
-            orderable: false,
-            render: function(data, type, row, meta) {
-              if ( Object.keys(row.amr).length > 0 ) {
-                return "<i title='Sample has AMR data' class='hasAMR fa fa-plus-square'></i>";
-              } else {
-                return "<i title='No AMR data for sample' class='noAMR fa fa-times'></i>";
-              }
-            }
-          }
+          { data: "isolate",                visible: false }
         ]
       } );
 

--- a/app/root/static/javascripts/samples.js
+++ b/app/root/static/javascripts/samples.js
@@ -1,0 +1,55 @@
+
+// samples.js
+// jt6 20150517 WTSI
+
+/* exported  samples*/
+
+var samples = (function() {
+  "use strict";
+
+  return {
+
+    // add listeners where needed
+    setupTable: function() {
+
+      $("#samples").dataTable( {
+        // dom: "T<'clear'>lfrtip",
+        serverSide: true,
+        ajax: {
+          url: window.location.href,
+          data: function(d) {
+            // add a param to signify that this request comes from DataTables
+            d._dt = 1;
+          }
+        }
+      } );
+
+      $("#samples_filter input").on("input change", function(e) {
+        var filterTerm = $(e.target).val();
+        if ( filterTerm === undefined || filterTerm == "" ) {
+          $("#filtered").hide();
+          $("#all").show();
+        } else {
+          $("#filtered").show();
+          $("#all").hide();
+        }
+      } );
+
+      $("button.table-download-link").on("click", function(e) {
+        var filterTerm = $("#samples_filter input").val(),
+            dlFormat   = e.target.dataset.format,
+            dlURL      = window.location.href;
+        dlURL += "?dl=1";
+        dlURL += "&content-type=" + encodeURIComponent(dlFormat);
+        if ( filterTerm !== undefined && filterTerm != "" ) {
+          dlURL += "&filter=" + encodeURIComponent(filterTerm);
+        }
+        console.debug( "redirecting to " + dlURL );
+        window.location.href = dlURL;
+      } );
+
+    }
+  };
+
+})();
+

--- a/app/root/static/javascripts/samples.js
+++ b/app/root/static/javascripts/samples.js
@@ -17,6 +17,7 @@ var samples = (function() {
           equality,
           susceptibilityClass;
 
+      table.push( "<div class='row'><div class='col-md-6'>" );
       table.push( "<table class='amrData table table-striped table-condensed'>" );
       table.push( "<thead><tr>" );
       table.push( "<th>Compound name</th>" );
@@ -46,6 +47,7 @@ var samples = (function() {
       } );
 
       table.push( "</tbody></table>" );
+      table.push( "</div></div>" );
 
       return table.join("");
     },
@@ -72,7 +74,33 @@ var samples = (function() {
                      row.sample_id + "</a>";
             }
           },
-          { data: "manifest_id" },
+          {
+            // manifest_id
+            render: function(data, type, row, meta) {
+              return "<a title='Show only samples from this manifest' " +
+                     "href='/samples?filter=" + row.manifest_id + "'>" +
+                     row.manifest_id + "</a>";
+            }
+          },
+          { data: "raw_data_accession" },
+          { data: "sample_accession" },
+          {
+            // sample_description
+            render: function(data, type, row, meta) {
+              var op = row.sample_description || "";
+              if ( op.length > 10 ) {
+                op = "<span class='expansion truncated'>" + op.substr(0, 10) +
+                     "<a title='See more'>&hellip;</a>" +
+                     "</span>" +
+                     "<span class='expansion fullLength'>" + op +
+                     " <a title='See less'>(hide)</a>" +
+                     "</span>";
+              }
+              return op;
+            }
+          },
+          { data: "collected_at" },
+          { data: "tax_id",                 visible: false },
           {
             // scientific_name
             orderData: 2,
@@ -80,13 +108,20 @@ var samples = (function() {
               return row.scientific_name + " (" + row.tax_id + ")";
             }
           },
-          {
-            //  tax_id
-            data: "tax_id",
-            visible: false
-          },
+          { data: "collected_by",           visible: false },
+          { data: "source",                 visible: false },
           { data: "collection_date" },
-          { data: "collected_at" },
+          { data: "location" },
+          { data: "host_associated" },
+          { data: "specific_host" },
+          { data: "host_disease_status" },
+          { data: "host_isolation_source" },
+          { data: "patient_location" },
+          { data: "isolation_source",       visible: false },
+          { data: "serovar" },
+          { data: "other_classification",   visible: false },
+          { data: "strain" },
+          { data: "isolate",                visible: false },
           {
             // AMR data
             className: "amrCell text-center",
@@ -128,6 +163,14 @@ var samples = (function() {
             hasAMR.removeClass("fa-plus-square")
                   .addClass("fa-minus-square");
           }
+        } );
+
+        $("#samples span.expansion > a").on("click", function(e) {
+          var link = e.target,
+              parentSpan = link.closest("span"),
+              siblingSpan = $(parentSpan).siblings()[0];
+          $(parentSpan).toggle();
+          $(siblingSpan).toggle();
         } );
 
       } );

--- a/app/root/static/javascripts/samples.js
+++ b/app/root/static/javascripts/samples.js
@@ -27,10 +27,8 @@ var samples = (function() {
       table.push( "<tbody>" );
 
       $.each( d.amr, function(i, amr) {
-        switch ( amr.susceptibility ) {
-          case "S": susceptibilityClass = "amrS"; break;
-          case "I": susceptibilityClass = "amrI"; break;
-          case "R": susceptibilityClass = "amrR";  break;
+        if ( amr.susceptibility.match("[SIR]") ) {
+          susceptibilityClass = "amr" + amr.susceptibility;
         }
         table.push( "<tr class='" + susceptibilityClass + "'>" );
         table.push( "<td class='amrName'>" + amr.antimicrobial_name + "</td>" );

--- a/app/root/static/javascripts/summary.js
+++ b/app/root/static/javascripts/summary.js
@@ -20,17 +20,13 @@ var summary = (function() {
 
       $("#sort-species").on("click", function() {
         var currentOrder = summary.organismTable.order(),
-            newOrder     = currentOrder[0][1] == "asc"
-                         ? "desc"
-                         : "asc";
+            newOrder     = currentOrder[0][1] === "asc" ? "desc" : "asc";
         summary.organismTable.order( [ 0, newOrder ] )
                              .draw();
       } );
       $("#sort-num-samples").on("click", function() {
         var currentOrder = summary.organismTable.order(),
-            newOrder     = currentOrder[0][1] == "asc"
-                         ? "desc"
-                         : "asc";
+            newOrder     = currentOrder[0][1] === "asc" ? "desc" : "asc";
         summary.organismTable.order( [ 1, newOrder ] )
                              .draw();
       } );

--- a/app/root/static/javascripts/summary.js
+++ b/app/root/static/javascripts/summary.js
@@ -1,0 +1,41 @@
+
+// summary.js
+// jt6 20150623 WTSI
+
+/* exported summary */
+
+var summary = (function() {
+  "use strict";
+
+  return {
+
+    // set up the tables in the page
+    setupTables: function() {
+      summary.organismTable = $("#organism-table").DataTable( {
+        dom: "t",
+        scrollY: "20em",
+        paging: false,
+        ordering: true
+      } );
+
+      $("#sort-species").on("click", function() {
+        var currentOrder = summary.organismTable.order(),
+            newOrder     = currentOrder[0][1] == "asc"
+                         ? "desc"
+                         : "asc";
+        summary.organismTable.order( [ 0, newOrder ] )
+                             .draw();
+      } );
+      $("#sort-num-samples").on("click", function() {
+        var currentOrder = summary.organismTable.order(),
+            newOrder     = currentOrder[0][1] == "asc"
+                         ? "desc"
+                         : "asc";
+        summary.organismTable.order( [ 1, newOrder ] )
+                             .draw();
+      } );
+    }
+  };
+
+})();
+

--- a/app/root/static/javascripts/summary.js
+++ b/app/root/static/javascripts/summary.js
@@ -11,7 +11,14 @@ var summary = (function() {
 
     // set up the tables in the page
     setupTables: function() {
-      summary.organismTable = $("#organism-table").DataTable( {
+      summary.organismTable = $("#organism-table").dataTable( {
+        dom: "t",
+        scrollY: "20em",
+        paging: false,
+        ordering: true
+      } );
+
+      summary.compoundTable = $("#compound-table").dataTable( {
         dom: "t",
         scrollY: "20em",
         paging: false,

--- a/app/root/static/javascripts/util.js
+++ b/app/root/static/javascripts/util.js
@@ -54,8 +54,16 @@ var HICF = {
   samples: {
     init: function() {
       "use strict";
-      $("#samples").DataTable( {
-        dom: "T<'clear'>lfrtip"
+      $("#samples").dataTable( {
+        dom: "T<'clear'>lfrtip",
+        serverSide: true,
+        ajax: {
+          url: "/samples",
+          data: function(d) {
+            // add a param to signify that this request comes from DataTables
+            d._dt = 1;
+          }
+        }
       } );
     }
   }

--- a/app/root/static/javascripts/util.js
+++ b/app/root/static/javascripts/util.js
@@ -65,6 +65,14 @@ var HICF = {
           }
         }
       } );
+
+      $("#table-download").on("click", function() {
+        var filterTerm   = $("#samples_filter input").val(),
+            downloadLink = $("#table-download")[0];
+        if ( filterTerm !== undefined ) {
+          downloadLink.href += "&filter=" + encodeURIComponent(filterTerm);
+        }
+      } );
     }
   }
 

--- a/app/root/static/javascripts/util.js
+++ b/app/root/static/javascripts/util.js
@@ -4,7 +4,7 @@
 //
 // see http://viget.com/inspire/extending-paul-irishs-comprehensive-dom-ready-execution
 
-/* global validation,fourohfour,login,account,samples */
+/* global validation,fourohfour,account,samples,summary,login */
 /* exported HICF */
 
 var HICF = {
@@ -48,6 +48,13 @@ var HICF = {
       "use strict";
       // action-specific code
       // console.debug( "index.clicked: action-specific code" );
+    }
+  },
+
+  summary: {
+    init: function() {
+      "use strict";
+      summary.setupTables();
     }
   },
 

--- a/app/root/static/javascripts/util.js
+++ b/app/root/static/javascripts/util.js
@@ -54,25 +54,7 @@ var HICF = {
   samples: {
     init: function() {
       "use strict";
-      $("#samples").dataTable( {
-        dom: "T<'clear'>lfrtip",
-        serverSide: true,
-        ajax: {
-          url: "/samples",
-          data: function(d) {
-            // add a param to signify that this request comes from DataTables
-            d._dt = 1;
-          }
-        }
-      } );
-
-      $("#table-download").on("click", function() {
-        var filterTerm   = $("#samples_filter input").val(),
-            downloadLink = $("#table-download")[0];
-        if ( filterTerm !== undefined ) {
-          downloadLink.href += "&filter=" + encodeURIComponent(filterTerm);
-        }
-      } );
+      samples.setupTable();
     }
   }
 

--- a/app/root/static/javascripts/util.js
+++ b/app/root/static/javascripts/util.js
@@ -4,7 +4,7 @@
 //
 // see http://viget.com/inspire/extending-paul-irishs-comprehensive-dom-ready-execution
 
-/* global validation,fourohfour,account,samples,sample,summary,login */
+/* global validation,fourohfour,account,samples,summary,login */
 /* exported HICF */
 
 var HICF = {
@@ -69,6 +69,7 @@ var HICF = {
     init: function() {
       "use strict";
       $("[data-toggle='tooltip']").tooltip();
+      $("#return-link").on("click", function() { window.history.back(); } );
     }
   }
 

--- a/app/root/static/javascripts/util.js
+++ b/app/root/static/javascripts/util.js
@@ -4,7 +4,7 @@
 //
 // see http://viget.com/inspire/extending-paul-irishs-comprehensive-dom-ready-execution
 
-/* global validation,fourohfour,login,account */
+/* global validation,fourohfour,login,account,samples */
 /* exported HICF */
 
 var HICF = {

--- a/app/root/static/javascripts/util.js
+++ b/app/root/static/javascripts/util.js
@@ -4,7 +4,7 @@
 //
 // see http://viget.com/inspire/extending-paul-irishs-comprehensive-dom-ready-execution
 
-/* global validation,fourohfour,account,samples,summary,login */
+/* global validation,fourohfour,account,samples,sample,summary,login */
 /* exported HICF */
 
 var HICF = {
@@ -62,6 +62,13 @@ var HICF = {
     init: function() {
       "use strict";
       samples.setupTable();
+    }
+  },
+
+  sample: {
+    init: function() {
+      "use strict";
+      $("[data-toggle='tooltip']").tooltip();
     }
   }
 

--- a/app/root/static/styles/samples.scss
+++ b/app/root/static/styles/samples.scss
@@ -1,7 +1,7 @@
 // samples.scss
 // jt6 20150529 WTSI
 //
-// rules for the samples page
+// rules for the samples (and sample) page
 
 @import "flatly/variables";
 
@@ -29,18 +29,6 @@ table#samples {
   i.hasAMR.fa-minus-square { color: #A00 } // dark red
   i.noAMR                  { color: #CCC } // greyed out
 
-  table.amrData {
-    td.amrName {
-      text-transform: capitalize;
-    }
-    td.amrSIR {
-      margin-left: 6px;
-    }
-    tr.amrS td { color: darken($brand-success, 10%) }
-    tr.amrI td { color: darken($brand-warning, 10%) }
-    tr.amrR td { color: darken($brand-danger,  10%) }
-  }
-
   span.expansion a {
     font-size: smaller;
   }
@@ -49,8 +37,36 @@ table#samples {
   }
 }
 
+table.amrData {
+  td.amrName {
+    text-transform: capitalize;
+  }
+  td.amrSIR {
+    margin-left: 6px;
+  }
+  tr.amrS td { color: darken($brand-success, 10%) }
+  tr.amrI td { color: darken($brand-warning, 10%) }
+  tr.amrR td { color: darken($brand-danger,  10%) }
+}
+
 #scrollbox {
   overflow-x: auto;
   width: 100%;
 }
 
+#sample {
+  table.two-column-narrow {
+    tr th:first-child,
+    tr td:first-child {
+      width: 30%;
+    }
+    tr th:last-child,
+    tr td:last-child {
+      width: 70%;
+    }
+  }
+  div.tooltip-inner {
+    text-align: left;
+    max-width: 400px;
+  }
+}

--- a/app/root/static/styles/samples.scss
+++ b/app/root/static/styles/samples.scss
@@ -9,15 +9,12 @@
   margin-bottom: 0 !important;
 }
 
-.dataTables_length,
-.dataTables_filter,
-.dataTables_info {
-  float: left;
-  margin-right: 1em;
-}
-
 th.row-label,
 td.row-label {
   width: 12em;
   font-weight: bold;
+}
+
+#filtered {
+  display: none;
 }

--- a/app/root/static/styles/samples.scss
+++ b/app/root/static/styles/samples.scss
@@ -16,3 +16,8 @@
   margin-right: 1em;
 }
 
+th.row-label,
+td.row-label {
+  width: 12em;
+  font-weight: bold;
+}

--- a/app/root/static/styles/samples.scss
+++ b/app/root/static/styles/samples.scss
@@ -18,3 +18,24 @@ td.row-label {
 #filtered {
   display: none;
 }
+
+table#samples {
+
+  i.hasAMR.fa-plus-square  { color: #0A0 } // dark green
+  i.hasAMR.fa-minus-square { color: #A00 } // dark red
+  i.noAMR                  { color: #CCC } // greyed out
+
+  table.amrData {
+    td.amrName {
+      text-transform: capitalize;
+    }
+    td.amrSIR {
+      margin-left: 6px;
+    }
+    tr.amrS td { color: darken($brand-success, 10%) }
+    tr.amrI td { color: darken($brand-warning, 10%) }
+    tr.amrR td { color: darken($brand-danger,  10%) }
+  }
+
+}
+

--- a/app/root/static/styles/samples.scss
+++ b/app/root/static/styles/samples.scss
@@ -19,7 +19,7 @@ td.row-label {
   display: none;
 }
 
-table#samples {
+table#samples-table {
 
   i.hasAMR {
     cursor: pointer;

--- a/app/root/static/styles/samples.scss
+++ b/app/root/static/styles/samples.scss
@@ -21,6 +21,10 @@ td.row-label {
 
 table#samples {
 
+  i.hasAMR {
+    cursor: pointer;
+  }
+
   i.hasAMR.fa-plus-square  { color: #0A0 } // dark green
   i.hasAMR.fa-minus-square { color: #A00 } // dark red
   i.noAMR                  { color: #CCC } // greyed out

--- a/app/root/static/styles/samples.scss
+++ b/app/root/static/styles/samples.scss
@@ -41,5 +41,16 @@ table#samples {
     tr.amrR td { color: darken($brand-danger,  10%) }
   }
 
+  span.expansion a {
+    font-size: smaller;
+  }
+  span.fullLength {
+    display: none;
+  }
+}
+
+#scrollbox {
+  overflow-x: auto;
+  width: 100%;
 }
 

--- a/app/root/static/styles/summary.scss
+++ b/app/root/static/styles/summary.scss
@@ -5,11 +5,15 @@
 
 @import "flatly/variables";
 
-tr td:first-child {
-  width: 60%;
+#summary {
+  table.two-column-narrow {
+    tr th:first-child,
+    tr td:first-child {
+      width: 60%;
+    }
+    tr th:last-child,
+    tr td:last-child {
+      width: 40%;
+    }
+  }
 }
-
-tr td:last-child {
-  width: 40%;
-}
-

--- a/app/root/static/styles/summary.scss
+++ b/app/root/static/styles/summary.scss
@@ -1,0 +1,15 @@
+// summary.scss
+// jt6 20150623 WTSI
+//
+// rules for the samples summary page
+
+@import "flatly/variables";
+
+tr td:first-child {
+  width: 60%;
+}
+
+tr td:last-child {
+  width: 40%;
+}
+

--- a/app/root/templates/components/navbar.tt
+++ b/app/root/templates/components/navbar.tt
@@ -27,8 +27,8 @@
         <div id="nav-tools" class="navbar-right col-md-6">
 
           [% IF c.user_exists %]
-          <div class="row">
-            <form class="navbar-form" role="search">
+          <form class="navbar-form" role="search">
+            <div class="row">
               <div class="col-md-10">
                   <div class="input-group input-group-sm pull-right">
                     <input type="text" class="form-control" placeholder="Search">
@@ -42,8 +42,8 @@
                         class="btn btn-default btn-sm"
                         type="button">Sign out</button>
               </div>
-            </form>
-          </div>
+            </div>
+          </form>
           <div class="row">
             <span class="signed-in col-md-offset-6 col-md-6 text-right">
               Signed in as

--- a/app/root/templates/pages/sample.tt
+++ b/app/root/templates/pages/sample.tt
@@ -1,5 +1,28 @@
+[%
+tooltips = {
+  raw_data_accession      => "Accession for raw data i.e. fastq/bam files",
+  sample_accession        => "Accession for the sample",
+  sample_description      => "Free-text description of the sample",
+  collected_at            => 'ID of the institute that performed the study',
+  tax_id                  => 'The taxonomy ID of the organism that provided the sequenced genetic material',
+  scientific_name         => 'The full scientific name of the organism that provided the sequenced genetic material',
+  collected_by            => 'Name of person(s) who may be contacted in the case of queries about the sample',
+  source                  => 'Information about the source of the sample',
+  collection_date         => 'Date and time that the specimen was collected',
+  location                => 'Locality of isolation of the sampled organism',
+  host_associated         => 'Is the organism from which the sample was obtained associated with a host organism ?',
+  specific_host           => 'Natural (as opposed to laboratory) host to the organism from which the sample was obtained (or &quot;free-living&quot; if not host associated)',
+  host_disease_status     => 'Condition of host. One of &quot;diseased&quot;, &quot;healthy&quot; or &quot;carriage&quot;',
+  host_isolation_source   => 'Name of host tissue or organ sampled for analysis',
+  patient_location        => 'Describes the health care situation of a human host when the sample was obtained. One of &quot;inpatient&quot; or &quot;community&quot;',
+  isolation_source        => 'Describes the physical, environmental and/or local geographical source of the biological sample from which the sample was derived',
+  serovar                 => 'Serological variety of a species characterised by its antigenic properties',
+  other_classification    => 'Appropriate classification terms for the sample organism',
+  strain                  => 'Name of strain from which sample was obtained',
+  isolate                 => 'Name of isolate from which sample was obtained',
+} %]
 
-<section class="container">
+<section class="container" id="sample">
 
   <h1>Sample[% " " _ id %]</h1>
 
@@ -14,30 +37,82 @@
     </div>
   [% ELSE %]
 
-  <table class="table table-striped table-condensed">
-    <thead>
-      <tr>
-        <th class="text-right row-label">Field</th>
-        <th>Value</th>
-      </tr>
-    </thead>
-    <tbody>
-      [% fields = sample.fields;
-      FOREACH field IN sample.field_names %]
-      <tr>
-        <td class="text-right row-label">[% field %]</td>
-        <td>
-        [% IF fields.$field.defined;
-          fields.$field;
-        ELSE %]
-          <span class="na">n/a</span>
-        [% END %]
-        </td>
-      </tr>
-      [% END %]
-    </tbody>
-  </table>
+  <div class="row">
+    <div class="col-md-7">
+      <h2>Sample metadata</h2>
+      <table class="two-column-narrow table table-striped table-condensed">
+        <thead>
+          <tr>
+            <th class="text-right row-label">Field</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          [% fields = sample.fields;
+          FOREACH field IN sample.field_names;
+            field_name = field.replace('_', ' ').ucfirst;
+            tooltip_text = tooltips.$field;
+            %]
+            <tr>
+              <td class="text-right row-label">
+                <div data-toggle="tooltip"
+                     data-placement="right"
+                     title="[% tooltip_text %]">
+                  [% field_name %]
+                </div>
+              </td>
+              <td>
+              [% IF fields.$field.defined;
+                fields.$field;
+              ELSE %]
+                <span class="na">n/a</span>
+              [% END %]
+              </td>
+            </tr>
+          [% END %]
+        </tbody>
+      </table>
+    </div>
 
-  [% END %]
+    <div class="col-md-5">
+      <h2>Antimicrobial resistance</h2>
+
+      [% IF sample.antimicrobial_resistances %]
+        <table class="amrData table table-striped table-condensed">
+          <thead>
+            <th>Compound name</th>
+            <th>Susceptibility</th>
+            <th>MIC</th>
+          </thead>
+          <tbody>
+          [% FOREACH amr IN sample.antimicrobial_resistances;
+            SWITCH amr.equality;
+              CASE 'le'; equality = '&le;';
+              CASE 'lt'; equality = '&lt;';
+              CASE 'eq'; equality = '';
+              CASE 'gt'; equality = '&gt;';
+              CASE 'ge'; equality = '&ge;';
+            END;
+            susceptibilityClass = 'amr' _ amr.susceptibility
+              IF amr.susceptibility.match('[SIR]') %]
+            <tr class="[% susceptibilityClass %]">
+              <td class="amrName">[% amr.get_column('antimicrobial_name') %]</td>
+              <td class="amrSIR">[% amr.susceptibility %]</td>
+              <td class="amrMIC">[% equality; amr.mic %]</td>
+            </tr>
+          [% END %]
+          </tbody>
+        </table>
+      [% ELSE %]
+        <p class="na">
+          There are no antimicrobial resistance test results associated with
+          this sample.
+        </p>
+      [% END %]
+    </div>
+  </div>
+
+  [% END # of "IF error" %]
 
 </section>
+

--- a/app/root/templates/pages/sample.tt
+++ b/app/root/templates/pages/sample.tt
@@ -109,6 +109,10 @@ tooltips = {
           this sample.
         </p>
       [% END %]
+
+      <p>
+        Go <a id="return-link">back</a> to the previous page.
+      </p>
     </div>
   </div>
 

--- a/app/root/templates/pages/sample.tt
+++ b/app/root/templates/pages/sample.tt
@@ -1,11 +1,7 @@
 
 <section class="container">
 
-  [% IF id %]
-  <h1>Sample &quot;[% id %]&quot;</h1>
-  [% ELSE %]
-  <h1>Sample</h1>
-  [% END %]
+  <h1>Sample[% " " _ id %]</h1>
 
   [% IF error %]
     <div class="panel panel-danger">
@@ -21,7 +17,7 @@
   <table class="table table-striped table-condensed">
     <thead>
       <tr>
-        <th>Field</th>
+        <th class="text-right row-label">Field</th>
         <th>Value</th>
       </tr>
     </thead>
@@ -29,7 +25,7 @@
       [% fields = sample.fields;
       FOREACH field IN sample.field_names %]
       <tr>
-        <td>[% field %]</td>
+        <td class="text-right row-label">[% field %]</td>
         <td>
         [% IF fields.$field.defined;
           fields.$field;

--- a/app/root/templates/pages/samples.tt
+++ b/app/root/templates/pages/samples.tt
@@ -26,7 +26,7 @@
         <tr>
           <th scope="row">Sample ID</th>
           <th>Manifest ID</th>
-          <th>Scientific name</th>
+          <th>Scientific name (NCBI tax ID)</th>
           <th>NCBI tax ID</th>
           <th>Collection date</th>
           <th>Collected at</th>

--- a/app/root/templates/pages/samples.tt
+++ b/app/root/templates/pages/samples.tt
@@ -3,36 +3,53 @@
 
   <h1>HICF samples</h1>
 
-  <table id="samples" class="table table-striped table-condensed table-bordered">
-    <thead>
-      <tr>
-        <th scope="row">Sample ID</th>
-        <th>Manifest ID</th>
-        <th>Scientific name</th>
-        <th>NCBI tax ID</th>
-        <th>Collection date</th>
-        <th>Collected at</th>
-      </tr>
-    </thead>
-    <tbody>
-      [% FOREACH sample IN samples.all %]
-      <tr>
-        <td scope="row" data-search="[% sample.sample_id %]">
-          <a href="[% c.uri_for('/sample', sample.sample_id) %]">[% sample.sample_id %]</a>
-        </td>
-        <td>[% sample.manifest_id %]</td>
-        <td data-search="[% sample.scientific_name %]">
-          <a class="ext" href="http://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=[% sample.tax_id %]">[% sample.scientific_name %]</a>
-        </td>
-        <td data-search="[% sample.scientific_name %]">
-          <a class="ext" href="http://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=[% sample.tax_id %]">[% sample.tax_id %]</a>
-        </td>
-        <td>[% sample.collection_date %]</td>
-        <td>[% sample.collected_at %]</td>
-      </tr>
-      [% END %]
-    </tbody>
-  </table>
+  [% IF error %]
+
+    <div id="organism-name-error" class="panel panel-warning">
+      <div class="panel-heading">Error</div>
+      <div class="panel-body">
+        <span id="error-message">[% error %]</span>
+      </div>
+    </div>
+
+  [% ELSE %]
+
+    <table id="samples" class="table table-striped table-condensed table-bordered">
+      <thead>
+        <tr>
+          <th scope="row">Sample ID</th>
+          <th>Manifest ID</th>
+          <th>Scientific name</th>
+          <th>NCBI tax ID</th>
+          <th>Collection date</th>
+          <th>Collected at</th>
+        </tr>
+      </thead>
+      <tbody>
+        [% FOREACH sample IN samples.all %]
+        <tr>
+          <td scope="row" data-search="[% sample.sample_id %]">
+            <a href="[% c.uri_for('/sample', sample.sample_id) %]">[% sample.sample_id %]</a>
+          </td>
+          <td>[% sample.manifest_id %]</td>
+          <td data-search="[% sample.scientific_name %]">
+            <a class="ext" href="http://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=[% sample.tax_id %]">[% sample.scientific_name %]</a>
+          </td>
+          <td data-search="[% sample.scientific_name %]">
+            <a class="ext" href="http://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=[% sample.tax_id %]">[% sample.tax_id %]</a>
+          </td>
+          <td>[% sample.collection_date %]</td>
+          <td>[% sample.collected_at %]</td>
+        </tr>
+        [% END %]
+      </tbody>
+    </table>
+
+    <p>
+      <a id="table-download" href="[% c.uri_for('/samples', { 'content-type' => 'text/csv' } ) %]">Download</a> table contents.
+    </p>
+
+  [% END # of "IF error" %]
 
 </section>
 

--- a/app/root/templates/pages/samples.tt
+++ b/app/root/templates/pages/samples.tt
@@ -1,9 +1,9 @@
 
 <section class="container">
 
-  <h1>HICF samples</h1>
-
   [% IF error %]
+
+    <h1>HICF samples</h1>
 
     <div id="organism-name-error" class="panel panel-warning">
       <div class="panel-heading">Error</div>
@@ -12,7 +12,14 @@
       </div>
     </div>
 
-  [% ELSE %]
+  [% ELSE;
+    titleComponents = [ "HICF samples" ];
+    titleComponents.push(" from $organism") IF organism;
+    titleComponents.push(", filtered by '${format_params.filter_term}'" )
+      IF format_params.filter_term;
+    pageTitle = titleComponents.join('') %]
+
+    <h1>[% pageTitle %]</h1>
 
     <table id="samples" class="table table-striped table-condensed table-bordered">
       <thead>
@@ -45,9 +52,21 @@
       </tbody>
     </table>
 
-    <p>
-      <a id="table-download" href="[% c.uri_for('/samples', { 'content-type' => 'text/csv' } ) %]">Download</a> table contents.
-    </p>
+    <div id="download-buttons">
+      <span>Download
+        <span id="filtered">filtered</span>
+        <span id="all">all</span>
+        data:
+      </span>
+      <button class="table-download-link btn btn-default btn-sm"
+              data-format="text/csv"
+              type="button"
+              class="btn btn-default">CSV</button>
+      <button class="table-download-link btn btn-default btn-sm"
+              data-format="application/json"
+              type="button"
+              class="btn btn-default">JSON</button>
+    </div>
 
   [% END # of "IF error" %]
 

--- a/app/root/templates/pages/samples.tt
+++ b/app/root/templates/pages/samples.tt
@@ -16,21 +16,34 @@
 
     <h1>
       HICF samples
-      [% " from $organism" IF organism;
-         " with $susceptibility AMR results" IF sir;
-         ", filtered by '${format_params.filter_term}'" IF format_params.filter_term;
-      IF organism or sir or format_params.filter_term -%]
-        <small>(<a href="[% c.uri_for('/samples') %]">Show all samples</a>)</small>
+      [% # build the page title based on what we find in the stash. A bit ugly
+      IF organism;
+        " from $organism";
+        show_all = 1;
+      ELSIF susceptibility AND antimicrobial;
+        " $susceptibility $antimicrobial";
+        show_all = 1;
+      ELSIF susceptibility;
+        " with $susceptibility AMR results";
+        show_all = 1;
+      ELSIF format_params.filter_term;
+        ", filtered by '${format_params.filter_term}'";
+        show_all = 1;
+      END;
+      IF show_all %]
+      <small>(<a href="[% c.uri_for('/samples') %]">Show all samples</a>)</small>
       [% END -%]
     </h1>
 
     <h1>[% pageTitle %]</h1>
 
     <div id="scrollbox">
-      <table id="samples" class="table table-striped table-condensed table-bordered">
+      <table id="samples-table"
+             class="table table-striped table-condensed table-bordered">
         <thead>
           <tr>
             <th scope="row">Sample ID</th>
+            <th>Has AMR<br />results</th>
             <th>Manifest ID</th>
             <th>Raw data accession</th>
             <th>Sample accession</th>
@@ -52,7 +65,6 @@
             <th>Other classification</th>
             <th>Strain</th>
             <th>Isolate</th>
-            <th>Has AMR</th>
           </tr>
         </thead>
       </table>

--- a/app/root/templates/pages/samples.tt
+++ b/app/root/templates/pages/samples.tt
@@ -1,5 +1,5 @@
 
-<section class="container">
+<section class="container" id="samples">
 
   [% IF error %]
 

--- a/app/root/templates/pages/samples.tt
+++ b/app/root/templates/pages/samples.tt
@@ -12,48 +12,51 @@
       </div>
     </div>
 
-  [% ELSE;
-    titleComponents = [ "HICF samples" ];
-    titleComponents.push(" from $organism") IF organism;
-    titleComponents.push(", filtered by '${format_params.filter_term}'" )
-      IF format_params.filter_term;
-    pageTitle = titleComponents.join('') %]
+  [% ELSE %]
+
+    <h1>
+      HICF samples
+      [% " from $organism" IF organism;
+         " with $susceptibility AMR results" IF sir;
+         ", filtered by '${format_params.filter_term}'" IF format_params.filter_term;
+      IF organism or sir or format_params.filter_term -%]
+        <small>(<a href="[% c.uri_for('/samples') %]">Show all samples</a>)</small>
+      [% END -%]
+    </h1>
 
     <h1>[% pageTitle %]</h1>
 
-    <table id="samples" class="table table-striped table-condensed table-bordered">
-      <thead>
-        <tr>
-          <th scope="row">Sample ID</th>
-          <th>Manifest ID</th>
-          <th>Scientific name (NCBI tax ID)</th>
-          <th>NCBI tax ID</th>
-          <th>Collection date</th>
-          <th>Collected at</th>
-          <th>Has AMR</th>
-        </tr>
-      </thead>
-      <!--
-      <tbody>
-        [% FOREACH sample IN samples.all %]
-        <tr>
-          <td scope="row" data-search="[% sample.sample_id %]">
-            <a href="[% c.uri_for('/sample', sample.sample_id) %]">[% sample.sample_id %]</a>
-          </td>
-          <td>[% sample.manifest_id %]</td>
-          <td data-search="[% sample.scientific_name %]">
-            <a class="ext" href="http://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=[% sample.tax_id %]">[% sample.scientific_name %]</a>
-          </td>
-          <td data-search="[% sample.scientific_name %]">
-            <a class="ext" href="http://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=[% sample.tax_id %]">[% sample.tax_id %]</a>
-          </td>
-          <td>[% sample.collection_date %]</td>
-          <td>[% sample.collected_at %]</td>
-        </tr>
-        [% END %]
-      </tbody>
-      -->
-    </table>
+    <div id="scrollbox">
+      <table id="samples" class="table table-striped table-condensed table-bordered">
+        <thead>
+          <tr>
+            <th scope="row">Sample ID</th>
+            <th>Manifest ID</th>
+            <th>Raw data accession</th>
+            <th>Sample accession</th>
+            <th>Description</th>
+            <th>Collected at</th>
+            <th>NCBI tax ID</th>
+            <th>Scientific name (NCBI tax ID)</th>
+            <th>Collected by</th>
+            <th>Source</th>
+            <th>Collection date</th>
+            <th>Location</th>
+            <th>Host associated</th>
+            <th>Specific host</th>
+            <th>Host disease status</th>
+            <th>Host isolation source</th>
+            <th>Patient location</th>
+            <th>Isolation source</th>
+            <th>Serovar</th>
+            <th>Other classification</th>
+            <th>Strain</th>
+            <th>Isolate</th>
+            <th>Has AMR</th>
+          </tr>
+        </thead>
+      </table>
+    </div>
 
     <div id="download-buttons">
       <span>Show <a href="[% c.uri_for('/samples') %]">all samples</a>.</span>

--- a/app/root/templates/pages/samples.tt
+++ b/app/root/templates/pages/samples.tt
@@ -30,8 +30,10 @@
           <th>NCBI tax ID</th>
           <th>Collection date</th>
           <th>Collected at</th>
+          <th>Has AMR</th>
         </tr>
       </thead>
+      <!--
       <tbody>
         [% FOREACH sample IN samples.all %]
         <tr>
@@ -50,13 +52,16 @@
         </tr>
         [% END %]
       </tbody>
+      -->
     </table>
 
     <div id="download-buttons">
+      <span>Show <a href="[% c.uri_for('/samples') %]">all samples</a>.</span>
+      <span>Show a <a href="[% c.uri_for('/summary') %]">summary</a> of current data.</span>
       <span>Download
         <span id="filtered">filtered</span>
         <span id="all">all</span>
-        data:
+        data in the table:
       </span>
       <button class="table-download-link btn btn-default btn-sm"
               data-format="text/csv"

--- a/app/root/templates/pages/summary.tt
+++ b/app/root/templates/pages/summary.tt
@@ -11,59 +11,151 @@
     </strong> samples from
     <strong>[% summary.total_number_of_manifests %]</strong> manifests.
     You can <a href="[% c.uri_for('/samples', { dl => 1, 'content-type' => 'text/csv' } ) %]">
-      download all samples</a> in <abbr title="Comma Separated Values">CSV</abbr> format.
+      download all samples</a> in CSV format.
   </p>
 
-  <h2>Number of samples from each contributing site</h2>
+  <h2>Per organism</h2>
 
-  <table class="table table-striped table-bordered table-condensed">
-    <thead>
-      <tr>
-        <th>Site</th>
-        <th>Number of samples (download as CSV)</th>
-      </tr>
-    </thead>
-    <tbody>
-      [% ca = summary.collected_at;
-      FOREACH site IN ca.keys.sort %]
-      <tr>
-        <td>
-          <a href="[% c.uri_for('/samples', { filter => site } ) %]">[% site %]</a>
-        </td>
-        <td>
-          <a href="[% c.uri_for('/samples', { dl => 1, filter => site, 'content-type' => 'text/csv' } ) %]">
-            [% ca.$site %]
-          </a>
-        </td>
-      </tr>
-      [% END %]
-    </tbody>
-  </table>
+  <div class="row">
 
-  <h2>Number of samples for each organism</h2>
+    <div class="col-md-6">
+      <table id="organism-table" class="table table-striped table-bordered table-condensed">
+        <thead>
+          <tr>
+            <th>Scientific name</th>
+            <th>Number of samples<br />(download as CSV)</th>
+          </tr>
+        </thead>
+        <tbody>
+          [% names = summary.scientific_names;
+          FOREACH name IN names.keys.sort;
+            name_encoded = name | uri %]
+          <tr>
+            <td>
+              <a title="See all samples from [% name %]"
+                 href="[% c.uri_for('/samples_from_organism', name_encoded ) %]">[% name %]</a>
+            </td>
+            <td>
+              <a title="Download all samples from [% name %]"
+                 href="[% c.uri_for('/samples_from_organism', name_encoded, { dl => 1, 'content-type' => 'text/csv' } ) %]">
+                [% names.$name %]</a>
+            </td>
+          </tr>
+          [% END %]
+        </tbody>
+      </table>
+    </div>
 
-  <table class="table table-striped table-bordered table-condensed">
-    <thead>
-      <tr>
-        <th>Scientific name</th>
-        <th>Number of samples (download as CSV)</th>
-      </tr>
-    </thead>
-    <tbody>
-      [% names = summary.scientific_names;
-      FOREACH name IN names.keys.sort;
-        organism = name | uri %]
-      <tr>
-        <td>
-          <a href="[% c.uri_for('/samples_from_organism', organism ) %]">[% name %]</a>
-        </td>
-        <td>
-          <a href="[% c.uri_for('/samples_from_organism', organism, { dl => 1, 'content-type' => 'text/csv' } ) %]">
-            [% names.$name %]</a>
-        </td>
-      </tr>
-      [% END %]
-    </tbody>
-  </table>
+    <div class="col-md-6">
+      <p>
+        This table shows the number of samples in the database, grouped by
+        sample organism. You can sort the table by <a id="sort-species">species
+        name</a> or by the <a id="sort-num-samples">number of samples</a> from
+        each organism. Scroll the table to see all organisms. Clicking on the
+        links in the left column will take you to a page that shows an
+        interactive table with sample metadata for all of the samples from the
+        chosen organism. Clicking links in the right column will download a CSV
+        (Comma Separated Values) file containing the same data that you can see
+        in the page.
+      </p>
+    </div>
+
+  </div>
+
+  <h2>Antimicrobial susceptibility</h2>
+
+  <div class="row">
+
+    <div class="col-md-6">
+
+      <table class="table table-striped table-bordered table-condensed">
+        <thead>
+          <tr>
+            <th>Susceptibility</th>
+            <th>Number of samples<br />(download as CSV)</th>
+          </tr>
+        </thead>
+        <tbody>
+          [% susceptibility = {
+            S => 'susceptible',
+            I => 'intermediate',
+            R => 'resistant',
+          };
+          FOREACH sir IN [ 'S', 'I', 'R' ];
+            s_count = summary.sir_counts.$sir %]
+          <tr>
+            <td>
+              <a title="See all samples that have one or more [% susceptibility.$sir %] AMR results"
+                 href="[% c.uri_for('/samples_with_susceptibility', sir ) %]">[% susceptibility.$sir.ucfirst %]</a>
+              (<a href="[% c.uri_for('/samples_with_susceptibility', sir ) %]">[% sir %]</a>)
+            </td>
+            <td>
+              <a title="Download all samples that have one or more [% susceptibility.$sir %] AMR results"
+                 href="[% c.uri_for('/samples_with_susceptibility', sir, { dl => 1, 'content-type' => 'text/csv' } ) %]">
+                [% s_count %]</a>
+            </td>
+          </tr>
+          [% END %]
+        </tbody>
+      </table>
+    </div>
+
+    <div class="col-md-6">
+      <p>
+        This table shows the number of samples that have one or more
+        antimicrobial resistance test results with the given susceptibility.
+        For example, there are <strong>[% summary.sir_counts.R %]</strong>
+        samples that have at least one result showing resistance to a given
+        antimicrobial.  Note that a sample that shows resistance to one
+        compound may also have AMR results showing susceptibility (or
+        intermediate susceptibility) to other compounds.
+      </p>
+    </div>
+
+  </div>
+
+  <h2>Contributing site</h2>
+
+  <div class="row">
+
+    <div class="col-md-6">
+      <table class="table table-striped table-bordered table-condensed">
+        <thead>
+          <tr>
+            <th>Site</th>
+            <th>Number of samples<br />(download as CSV)</th>
+          </tr>
+        </thead>
+        <tbody>
+          [% ca = summary.collected_at;
+          FOREACH site IN ca.keys.sort;
+            site_string = site == 'UCL'
+                        ? 'UCL'
+                        : site.lower.ucfirst %]
+          <tr>
+            <td>
+              <a title="See all samples contributed by [% site_string %]"
+                 href="[% c.uri_for('/samples', { filter => site } ) %]">[% site_string %]</a>
+            </td>
+            <td>
+              <a title="Download all samples contributed by [% site_string %]"
+                 href="[% c.uri_for('/samples', { dl => 1, filter => site, 'content-type' => 'text/csv' } ) %]">
+                [% ca.$site %]
+              </a>
+            </td>
+          </tr>
+          [% END %]
+        </tbody>
+      </table>
+    </div>
+
+    <div class="col-md-6">
+      <p>
+        This table shows the number of samples that have been submitted by each
+        of the three sites in the consortium.
+      </p>
+    </div>
+
+  </div>
 
 </section>

--- a/app/root/templates/pages/summary.tt
+++ b/app/root/templates/pages/summary.tt
@@ -1,47 +1,66 @@
 
 <section class="container">
 
-  <h1>Sample summary</h1>
+  <h1>HICF sample summary</h1>
 
   <p>
     The HICF sample database currently contains a total of
-    <strong>[% summary.total_number_of_samples %]</strong> samples from
+    <strong>
+      <a href="[% c.uri_for('/samples') %]">
+        [% summary.total_number_of_samples %]</a>
+    </strong> samples
+      (<a href="[% c.uri_for('/samples', { dl => 1, 'content-type' => 'text/csv' } ) %]">download as CSV</a>)
+    from
     <strong>[% summary.total_number_of_manifests %]</strong> manifests.
   </p>
 
+  <h2>Number of samples from each contributing site</h2>
+
   <table class="table table-striped table-bordered table-condensed">
-    <caption>Number of samples from each contributing site</caption>
     <thead>
       <tr>
         <th>Site</th>
-        <th>Number of samples</th>
+        <th>Number of samples (download as CSV)</th>
       </tr>
     </thead>
     <tbody>
       [% ca = summary.collected_at;
       FOREACH site IN ca.keys.sort %]
       <tr>
-        <td>[% site %]</td>
-        <td>[% ca.$site %]</td>
+        <td>
+          <a href="[% c.uri_for('/samples', { filter => site } ) %]">[% site %]</a>
+        </td>
+        <td>
+          <a href="[% c.uri_for('/samples', { dl => 1, filter => site, 'content-type' => 'text/csv' } ) %]">
+            [% ca.$site %]
+          </a>
+        </td>
       </tr>
       [% END %]
     </tbody>
   </table>
 
+  <h2>Number of samples for each organism</h2>
+
   <table class="table table-striped table-bordered table-condensed">
-    <caption>Number of samples for each organism</caption>
     <thead>
       <tr>
         <th>Scientific name</th>
-        <th>Number of samples</th>
+        <th>Number of samples (download as CSV)</th>
       </tr>
     </thead>
     <tbody>
       [% names = summary.scientific_names;
-      FOREACH name IN names.keys.sort %]
+      FOREACH name IN names.keys.sort;
+        organism = name | uri %]
       <tr>
-        <td>[% name %]</td>
-        <td>[% names.$name %]</td>
+        <td>
+          <a href="[% c.uri_for('/samples_from_organism', organism ) %]">[% name %]</a>
+        </td>
+        <td>
+          <a href="[% c.uri_for('/samples_from_organism', organism, { dl => 1, 'content-type' => 'text/csv' } ) %]">
+            [% names.$name %]</a>
+        </td>
       </tr>
       [% END %]
     </tbody>

--- a/app/root/templates/pages/summary.tt
+++ b/app/root/templates/pages/summary.tt
@@ -1,5 +1,5 @@
 
-<section class="container">
+<section class="container" id="summary">
 
   <h1>HICF sample summary</h1>
 
@@ -19,7 +19,7 @@
   <div class="row">
 
     <div class="col-md-6">
-      <table id="organism-table" class="table table-striped table-bordered table-condensed">
+      <table id="organism-table" class="two-column-narrow table table-striped table-bordered table-condensed">
         <thead>
           <tr>
             <th>Scientific name</th>
@@ -68,7 +68,7 @@
 
     <div class="col-md-6">
 
-      <table class="table table-striped table-bordered table-condensed">
+      <table class="two-column-narrow table table-striped table-bordered table-condensed">
         <thead>
           <tr>
             <th>Susceptibility</th>
@@ -119,7 +119,7 @@
   <div class="row">
 
     <div class="col-md-6">
-      <table class="table table-striped table-bordered table-condensed">
+      <table class="two-column-narrow table table-striped table-bordered table-condensed">
         <thead>
           <tr>
             <th>Site</th>

--- a/app/root/templates/pages/summary.tt
+++ b/app/root/templates/pages/summary.tt
@@ -132,31 +132,27 @@
           [% FOREACH antimicrobial_name IN summary.compound_counts.keys.sort %]
           <tr>
             <td>
-              <a data-toggle="tooltip"
-                 title="Show all samples with AMR results for [% antimicrobial_name %]"
+              <a title="Show all samples with AMR results for [% antimicrobial_name %]"
                  href="[% c.uri_for('/samples_by_antimicrobial', antimicrobial_name ) %]">
                 [% antimicrobial_name.ucfirst %]</a>
             </td>
             <td>
               [% IF summary.compound_counts.$antimicrobial_name.S %]
-              <a data-toggle="tooltip"
-                 title="Show samples that are susceptible to [% antimicrobial_name %]"
+              <a title="Show samples that are susceptible to [% antimicrobial_name %]"
                  href="[% c.uri_for('/samples_by_antimicrobial', antimicrobial_name, 'S' ) %]">
                 [% summary.compound_counts.$antimicrobial_name.S %]</a>
               [% ELSE %]0[%END %]
             </td>
             <td>
               [% IF summary.compound_counts.$antimicrobial_name.I %]
-              <a data-toggle="tooltip"
-                 title="Show samples that have intermediate susceptibility to [% antimicrobial_name %]"
+              <a title="Show samples that have intermediate susceptibility to [% antimicrobial_name %]"
                  href="[% c.uri_for('/samples_by_antimicrobial', antimicrobial_name, 'I' ) %]">
                 [% summary.compound_counts.$antimicrobial_name.I || 0 %]</a>
               [% ELSE %]0[%END %]
             </td>
             <td>
               [% IF summary.compound_counts.$antimicrobial_name.R %]
-              <a  data-toggle="tooltip"
-                 title="Show samples that are resistant to [% antimicrobial_name %]"
+              <a title="Show samples that are resistant to [% antimicrobial_name %]"
                  href="[% c.uri_for('/samples_by_antimicrobial', antimicrobial_name, 'R' ) %]">
                 [% summary.compound_counts.$antimicrobial_name.R || 0 %]</a>
               [% ELSE %]0[%END %]
@@ -169,8 +165,8 @@
 
     <div class="col-md-6">
       <p>
-        This table shows the antimicrobial susceptibility by compound. Links in
-        the first column will take you an interactive table showing all samples
+        This table shows antimicrobial susceptibility by compound. Links in the
+        first column will take you an interactive table showing all samples
         that have AMR results for the given antimicrobial. Links in the
         remaining columns show samples that have AMR results exhibiting
         susceptibility, intermediate susceptibility, or resistance to the given

--- a/app/root/templates/pages/summary.tt
+++ b/app/root/templates/pages/summary.tt
@@ -106,13 +106,80 @@
         antimicrobial resistance test results with the given susceptibility.
         For example, there are <strong>[% summary.sir_counts.R %]</strong>
         samples that have at least one result showing resistance to a given
-        antimicrobial.  Note that a sample that shows resistance to one
-        compound may also have AMR results showing susceptibility (or
-        intermediate susceptibility) to other compounds.
+        antimicrobial. Note that many samples have test results for multiple
+        antimicrobial compounds, so a sample that shows, for example,
+        resistance to one compound may also have AMR results showing
+        susceptibility or intermediate susceptibility to other compounds.
       </p>
     </div>
 
   </div>
+
+  <div class="row">
+
+    <div class="col-md-6">
+      <table id="compound-table"
+             class="table table-striped table-bordered table-condensed">
+        <thead>
+          <tr>
+            <th>Antimicrobial compound</th>
+            <th>Susceptible</th>
+            <th>Intermediate</th>
+            <th>Resistant</th>
+          </tr>
+        </thead>
+        <tbody>
+          [% FOREACH antimicrobial_name IN summary.compound_counts.keys.sort %]
+          <tr>
+            <td>
+              <a data-toggle="tooltip"
+                 title="Show all samples with AMR results for [% antimicrobial_name %]"
+                 href="[% c.uri_for('/samples_by_antimicrobial', antimicrobial_name ) %]">
+                [% antimicrobial_name.ucfirst %]</a>
+            </td>
+            <td>
+              [% IF summary.compound_counts.$antimicrobial_name.S %]
+              <a data-toggle="tooltip"
+                 title="Show samples that are susceptible to [% antimicrobial_name %]"
+                 href="[% c.uri_for('/samples_by_antimicrobial', antimicrobial_name, 'S' ) %]">
+                [% summary.compound_counts.$antimicrobial_name.S %]</a>
+              [% ELSE %]0[%END %]
+            </td>
+            <td>
+              [% IF summary.compound_counts.$antimicrobial_name.I %]
+              <a data-toggle="tooltip"
+                 title="Show samples that have intermediate susceptibility to [% antimicrobial_name %]"
+                 href="[% c.uri_for('/samples_by_antimicrobial', antimicrobial_name, 'I' ) %]">
+                [% summary.compound_counts.$antimicrobial_name.I || 0 %]</a>
+              [% ELSE %]0[%END %]
+            </td>
+            <td>
+              [% IF summary.compound_counts.$antimicrobial_name.R %]
+              <a  data-toggle="tooltip"
+                 title="Show samples that are resistant to [% antimicrobial_name %]"
+                 href="[% c.uri_for('/samples_by_antimicrobial', antimicrobial_name, 'R' ) %]">
+                [% summary.compound_counts.$antimicrobial_name.R || 0 %]</a>
+              [% ELSE %]0[%END %]
+            </td>
+          </tr>
+          [% END %]
+        </tbody>
+      </table>
+    </div>
+
+    <div class="col-md-6">
+      <p>
+        This table shows the antimicrobial susceptibility by compound. Links in
+        the first column will take you an interactive table showing all samples
+        that have AMR results for the given antimicrobial. Links in the
+        remaining columns show samples that have AMR results exhibiting
+        susceptibility, intermediate susceptibility, or resistance to the given
+        antimicrobial.
+      </p>
+    </div>
+
+  </div>
+
 
   <h2>Contributing site</h2>
 

--- a/app/root/templates/pages/summary.tt
+++ b/app/root/templates/pages/summary.tt
@@ -8,10 +8,10 @@
     <strong>
       <a href="[% c.uri_for('/samples') %]">
         [% summary.total_number_of_samples %]</a>
-    </strong> samples
-      (<a href="[% c.uri_for('/samples', { dl => 1, 'content-type' => 'text/csv' } ) %]">download as CSV</a>)
-    from
+    </strong> samples from
     <strong>[% summary.total_number_of_manifests %]</strong> manifests.
+    You can <a href="[% c.uri_for('/samples', { dl => 1, 'content-type' => 'text/csv' } ) %]">
+      download all samples</a> in <abbr title="Comma Separated Values">CSV</abbr> format.
   </p>
 
   <h2>Number of samples from each contributing site</h2>

--- a/app/root/templates/wrapper.tt
+++ b/app/root/templates/wrapper.tt
@@ -25,10 +25,10 @@
     <link href="/styles/contact-us.css" rel="stylesheet">
     <link href="/styles/validation.css" rel="stylesheet">
     <link href="/styles/samples.css" rel="stylesheet">
+    <link href="/styles/summary.css" rel="stylesheet">
     <link href="/styles/reset.css" rel="stylesheet">
     <link href="/styles/images.css" rel="stylesheet">
     <link href="/styles/vendor/dataTables.bootstrap.css" rel="stylesheet">
-    <link href="/styles/vendor/dataTables.tableTools.css" rel="stylesheet">
     <!-- endbuild -->
     <!-- <link href="/styles/vendor/jquery.dataTables.css" rel="stylesheet"> -->
 
@@ -78,9 +78,9 @@
     <script src="/javascripts/fourohfour.js"></script>
     <script src="/javascripts/validation.js"></script>
     <script src="/javascripts/samples.js"></script>
+    <script src="/javascripts/summary.js"></script>
     <script src="/javascripts/vendor/jquery.dataTables.js"></script>
     <script src="/javascripts/vendor/dataTables.bootstrap.js"></script>
-    <script src="/javascripts/vendor/dataTables.tableTools.js"></script>
     <!-- endbuild -->
 
   </body>

--- a/app/root/templates/wrapper.tt
+++ b/app/root/templates/wrapper.tt
@@ -77,6 +77,7 @@
     <script src="/javascripts/account.js"></script>
     <script src="/javascripts/fourohfour.js"></script>
     <script src="/javascripts/validation.js"></script>
+    <script src="/javascripts/samples.js"></script>
     <script src="/javascripts/vendor/jquery.dataTables.js"></script>
     <script src="/javascripts/vendor/dataTables.bootstrap.js"></script>
     <script src="/javascripts/vendor/dataTables.tableTools.js"></script>


### PR DESCRIPTION
This is an overly large merge but the bulk of it is a single controller, Sample.pm. The changes add a set of actions that display various subsets of sample data in an interactive table. The actions are essentially just wiring between the DB API and the template/JS controller that does the rendering. 

This merge also fleshes out the summary page, using more data that comes from the DB API, and the page showing a single sample. The single sample page is now nicely styled and includes AMR data that wasn't present before.