### PR TITLE
Correct case of filename

### DIFF
--- a/app/lib/MIDAS/Controller/Root.pm
+++ b/app/lib/MIDAS/Controller/Root.pm
@@ -90,7 +90,7 @@ sub api : Local Args(0) {
 
   $c->stash(
     breadcrumbs  => ['API'],
-    template     => 'pages/API.tt',
+    template     => 'pages/api.tt',
     title        => 'API',
     jscontroller => 'api',
   );


### PR DESCRIPTION
Fix the filename for the template that generates the API page. The filename was previously given as "pages/API.tt", where the file is actually "pages/api.tt".

It turns out that OSX, in its infinite wisdom, is happy to ignore the case and find the file anyway, so the bug only becomes obvious when you run the app on a linux box, where it sensibly throws an error about a missing file.