### PR TITLE
Set max length for organism table

### DIFF
--- a/app/root/static/javascripts/summary.js
+++ b/app/root/static/javascripts/summary.js
@@ -13,7 +13,7 @@ var summary = (function() {
     setupTables: function() {
       summary.organismTable = $("#organism-table").dataTable( {
         dom: "t",
-        // scrollY: "20em",
+        scrollY: "20em",
         paging: false,
         ordering: true
       } );


### PR DESCRIPTION
Turns out that, after fixing a bug in the API, the table of samples grouped by organism is now long enough to warrant having a maximum length assigned.