### PR TITLE
Fix sort links in summary text

### DIFF
--- a/app/root/static/javascripts/summary.js
+++ b/app/root/static/javascripts/summary.js
@@ -11,14 +11,14 @@ var summary = (function() {
 
     // set up the tables in the page
     setupTables: function() {
-      summary.organismTable = $("#organism-table").dataTable( {
+      summary.organismTable = $("#organism-table").DataTable( {
         dom: "t",
         scrollY: "20em",
         paging: false,
         ordering: true
       } );
 
-      summary.compoundTable = $("#compound-table").dataTable( {
+      summary.compoundTable = $("#compound-table").DataTable( {
         dom: "t",
         scrollY: "20em",
         paging: false,


### PR DESCRIPTION
There are two small DataTable tables in the page. We have links next to one of the, which should let the user sort the table in different ways. There was a bug in the JS that hooks in those links, meaning that they didn't point to the table object and therefore didn't work. This commit fixes that.