### PR TITLE
Add links

### DIFF
--- a/app/root/static/javascripts/samples.js
+++ b/app/root/static/javascripts/samples.js
@@ -109,13 +109,28 @@ var samples = (function() {
                      row.manifest_id + "</a>";
             }
           },
-          { data: "raw_data_accession", render: renderer },
-          { data: "sample_accession",   render: renderer },
+          {
+            // raw_data_accession
+            render: function(data, type, row, meta) {
+              return "<a class='ext' href='http://www.ebi.ac.uk/ena/data/view/" +
+                     row.raw_data_accession + "'>" + row.raw_data_accession + "</a>";
+            }
+          },
+          {
+            // sample_accession
+            render: function(data, type, row, meta) {
+              return "<a class='ext' href='http://www.ebi.ac.uk/ena/data/view/" +
+                     row.sample_accession + "'>" + row.sample_accession + "</a>";
+            }
+          },
           {
             // sample_description
             render: function(data, type, row, meta) {
               var op = row.sample_description || "";
-              if ( op.length > 10 ) {
+              if ( op.length < 1 ) {
+                op = "<span class='na'>n/a</span>";
+              }
+              else if ( op.length > 10 ) {
                 op = "<span class='expansion truncated'>" + op.substr(0, 10) +
                      "<a title='See more'>&hellip;</a>" +
                      "</span>" +
@@ -129,9 +144,11 @@ var samples = (function() {
           { data: "collected_at", render: renderer },
           { data: "tax_id", visible: false },
           {
-            // scientific_name
+            // scientific_name / tax_id
             render: function(data, type, row, meta) {
-              return row.scientific_name + " (" + row.tax_id + ")";
+              return "<a class='ext' href='http://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=" +
+                     row.tax_id + "'>" + row.scientific_name + "</a>" +
+                     " (" + row.tax_id + ")";
             }
           },
           { data: "collected_by",            render: renderer },

--- a/app/root/templates/pages/sample.tt
+++ b/app/root/templates/pages/sample.tt
@@ -20,7 +20,22 @@ tooltips = {
   other_classification    => 'Appropriate classification terms for the sample organism',
   strain                  => 'Name of strain from which sample was obtained',
   isolate                 => 'Name of isolate from which sample was obtained',
-} %]
+};
+links = {
+  raw_data_accession      => "http://www.ebi.ac.uk/ena/data/view/%s",
+  sample_accession        => "http://www.ebi.ac.uk/ena/data/view/%s",
+  tax_id                  => "http://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=%s",
+  location                => "http://www.ebi.ac.uk/ontology-lookup/?termId=%s",
+  host_isolation_source   => "http://www.ebi.ac.uk/ontology-lookup/?termId=%s",
+};
+
+BLOCK addLink -%]
+  <a class="ext" href="[% url.replace('%s', id) %]">[% id %]</a>
+[%- END;
+
+# TODO add code to convert fields into links
+# TODO fix tooltips in sample page
+%]
 
 <section class="container" id="sample">
 
@@ -56,14 +71,18 @@ tooltips = {
             <tr>
               <td class="text-right row-label">
                 <div data-toggle="tooltip"
-                     data-placement="right"
+                     data-placement="bottom"
                      title="[% tooltip_text %]">
                   [% field_name %]
                 </div>
               </td>
               <td>
               [% IF fields.$field.defined;
-                fields.$field;
+                IF links.$field.defined;
+                  PROCESS addLink url=links.$field id=fields.$field;
+                ELSE;
+                  fields.$field;
+                END;
               ELSE %]
                 <span class="na">n/a</span>
               [% END %]

--- a/app/root/templates/pages/sample.tt
+++ b/app/root/templates/pages/sample.tt
@@ -31,11 +31,7 @@ links = {
 
 BLOCK addLink -%]
   <a class="ext" href="[% url.replace('%s', id) %]">[% id %]</a>
-[%- END;
-
-# TODO add code to convert fields into links
-# TODO fix tooltips in sample page
-%]
+[%- END %]
 
 <section class="container" id="sample">
 

--- a/app/root/templates/wrapper.tt
+++ b/app/root/templates/wrapper.tt
@@ -71,8 +71,8 @@
     <script type="text/javascript" src="/zxtm/piwik2.js"></script>
     [% END -%]
 
+    [%# TODO get things like jquery from bower %]
     <script src="//code.jquery.com/jquery-2.1.4.min.js"></script>
-    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
 
     <!-- build:js({app/root/static,.tmp}) /javascripts/app.js -->
     <script src="/javascripts/util.js"></script>
@@ -87,6 +87,10 @@
     <script src="/javascripts/vendor/jquery-ui-1.9.1.custom.min.js"></script>
     <script src="/javascripts/vendor/jquery.tocify.min.js"></script>
     <!-- endbuild -->
+
+    [%# bootstrap.js needs to be loaded AFTER jquery.js and jquery-ui.js.
+        See http://stackoverflow.com/questions/17458224/uncaught-error-no-such-method-show-for-tooltip-widget-instance %]
+    <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
 
   </body>
 


### PR DESCRIPTION
This merge adds some links to the table that displays metadata for lots of samples, and to the page that displays all data for a single sample. It also fixes a bug with the behaviour of tooltips which was introduced in the last pull.