### PR TITLE
Add antimicrobials list

### DIFF
--- a/app/lib/MIDAS/Controller/Root.pm
+++ b/app/lib/MIDAS/Controller/Root.pm
@@ -97,6 +97,64 @@ sub api : Local Args(0) {
 }
 
 #-------------------------------------------------------------------------------
+
+=head2 antimicrobials
+
+Returns the list of currently registered antimicrobial compound names as a
+plain text file. Since this list could include sensitive information, this
+action requires authentication.
+
+Unless the C<NO_CACHE> environment variable is set to true, the list will be
+cached when first generated and returned from cache subsequently.
+
+=cut
+
+sub antimicrobials : Local
+                     Args(0)
+                     Does('~NeedsAuth') {
+  my ( $self, $c ) = @_;
+
+  my $cache_key = 'antimicrobial_names';
+
+  # take note of the NO_CACHE env variable. If set, don't try to read from or
+  # push to the cache
+  my $names = $ENV{NO_CACHE}
+            ? ''
+            : $c->cache->get($cache_key);
+
+  if ( $names ) {
+    $c->log->debug( 'Root::antimicrobials: retrieved list from cache' )
+      if $c->debug;
+  }
+  else {
+    $c->log->debug( 'Root::antimicrobials: failed to retrieve list from cache; generating' )
+      if $c->debug;
+
+    my @names = $c->model('HICFDB::Antimicrobial')->search(
+      {},
+      {
+        order_by => { -asc => 'name' },
+        columns  => [ 'name' ],
+      }
+    );
+
+    my $now = DateTime->now;
+    $names = <<EOF_header;
+# antimicrobial compound names accepted by MIDAS
+# generated $now
+EOF_header
+
+    $names .= $_->name . "\n" foreach @names;
+
+    $c->cache->set($cache_key, $names) unless $ENV{NO_CACHE};
+  }
+
+  $c->res->content_type('text/plain');
+  $c->res->header('Content-disposition', qq(attachment; filename="MIDAS_antimicrobials.txt"));
+  $c->res->body($names);
+}
+
+#-------------------------------------------------------------------------------
 #- boilerplate actions ---------------------------------------------------------
 #-------------------------------------------------------------------------------
 

--- a/app/root/templates/pages/summary.tt
+++ b/app/root/templates/pages/summary.tt
@@ -174,6 +174,11 @@
         susceptibility, intermediate susceptibility, or resistance to the given
         antimicrobial.
       </p>
+      <p>
+        When antimicrobial test results are loaded into the database, the
+        compound names are checked against a curated list of compound names.
+        You can download the list, in plain text,
+        <a class="dl" href="[% c.uri_for('/antimicrobials') %]">here</a>.
     </div>
 
   </div>

--- a/app/t/data/testing_antimicrobials.conf
+++ b/app/t/data/testing_antimicrobials.conf
@@ -1,0 +1,52 @@
+# midas_testing.conf
+# jt6 20150316 WTSI
+#
+# this is a local configuration file for the MIDAS webapp. It is intended for
+# use by the tests, which set the environment variable CATALYST_CONFIG_LOCAL_SUFFIX
+# to make sure it's used to override the settings in lib/MIDAS.pm
+
+disable_piwik 1
+
+disable_signin 0
+
+using_frontend_proxy 0
+
+<audit_log>
+  dir  /tmp
+</audit_log>
+
+# this overrides the setting in MIDAS.pm, which sets cookies to be https-only.
+# Tests involving logging in will fail unless this is set false, otherwise the
+# session cookie doesn't get set by the test server
+<Plugin::Session>
+  cookie_secure 0
+</Plugin::Session>
+
+<Model::HICFDB>
+  <connect_info>
+    dsn  dbi:SQLite:dbname=temp_data.db
+  </connect_info>
+</Model::HICFDB>
+
+<Model::UserDB>
+  <connect_info>
+    dsn  dbi:SQLite:dbname=temp_user.db
+  </connect_info>
+</Model::UserDB>
+
+<Controller::Validation>
+  # set up the checklist. The checklist configuration file needs to point at
+  # the ontology and taxonomy names.dmp files
+  checklist_file t/data/validation_checklist.conf
+
+  # upload expiry time, in seconds
+  upload_file_lifetime 3600
+</Controller::Validation>
+
+<Plugin::Cache>
+  <backend>
+    namespace MIDAS:
+    class     Cache::FastMmap
+  </backend>
+</Plugin::Cache>
+

--- a/app/t/pages/antimicrobials.t
+++ b/app/t/pages/antimicrobials.t
@@ -1,0 +1,52 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use File::Copy;
+use JSON;
+
+BEGIN {
+  $ENV{MIDAS_CONFIG}                 = 't/data/testing.conf';
+  $ENV{CATALYST_CONFIG_LOCAL_SUFFIX} = 'antimicrobials';
+  use_ok("Test::WWW::Mechanize::Catalyst" => 'MIDAS');
+}
+
+# clone the test databases, so that changes don't break the originals
+copy 't/data/user.db', 'temp_user.db';
+copy 't/data/data.db', 'temp_data.db';
+
+my $mech = Test::WWW::Mechanize::Catalyst->new;
+$mech->add_header( 'Content-Type' => 'text/html' );
+
+# check that we need to login to access the list
+$mech->get_ok('/antimicrobials', 'got antimicrobials list');
+$mech->content_contains('Sign in', "can't see list without signing in");
+
+# go ahead and login
+$mech->submit_form(
+  form_number => 1,
+  fields => {
+    username => 'testuser',
+    password => 'password',
+  }
+);
+
+# should get handed the file now
+is $mech->content_type, 'text/plain', 'got plain text response';
+$mech->content_contains('# antimicrobial compound names', 'found header');
+$mech->content_contains('am1', 'found compound 1');
+$mech->content_contains('am2', 'found compound 2');
+
+# check link
+$mech->get_ok('/summary', 'got summary page');
+$mech->content_contains('You can download the list', 'found link');
+$mech->follow_link(url_regex => qr/antimicrobials/);
+
+$mech->content_contains('# antimicrobial compound names', 'found header');
+$mech->content_contains('am1', 'found compound 1');
+$mech->content_contains('am2', 'found compound 2');
+
+done_testing;
+


### PR DESCRIPTION
This merge adds a method to generate a list of the antimicrobial compounds in the database and adds a link to that method to the data summary page. There's also a new test file and associated configuration file.