### PR TITLE
Gzip validated file

### DIFF
--- a/app/lib/MIDAS/Controller/Validation.pm
+++ b/app/lib/MIDAS/Controller/Validation.pm
@@ -239,9 +239,8 @@ sub return_validated_file : Chained('/') PathPart('validate') Args(1) {
     return;
   }
 
-  my $validated_filename  = 'validated_' . $file_hash->{filename};
-  my $compressed_contents = $file_hash->{contents};
-  my $validated_contents  = Compress::Zlib::memGunzip( $file_hash->{contents} );
+  my $validated_filename = 'validated_' . $file_hash->{filename};
+  my $validated_contents = Compress::Zlib::memGunzip( $file_hash->{contents} );
 
   unless ( $validated_contents ) {
     $c->log->error("Didn't get validated file contents from cache");

--- a/app/lib/MIDAS/Controller/Validation.pm
+++ b/app/lib/MIDAS/Controller/Validation.pm
@@ -6,6 +6,7 @@ use namespace::autoclean;
 
 use Data::UUID;
 use Try::Tiny;
+use Compress::Zlib;
 
 use Bio::Metadata::Checklist;
 use Bio::Metadata::Reader;
@@ -169,11 +170,13 @@ sub validate_upload : Chained('/') PathPart('validate') Args(0) {
     $c->log->debug( 'file was INvalid' )
       if $c->debug;
 
-    my $file_contents = $manifest->get_csv;
+    my $validated_csv = $manifest->get_csv;
+    my $file_contents = Compress::Zlib::memGzip($validated_csv);
+
     unless ( $file_contents ) {
-      $c->log->error("Couldn't read uploaded file: $!");
+      $c->log->error("Couldn't retrieve or compress validated file: $!");
       $c->res->status(500); # internal server error
-      $c->res->body("Couldn't read your CSV file");
+      $c->res->body("Couldn't save your validated CSV file");
       return;
     }
 
@@ -236,8 +239,9 @@ sub return_validated_file : Chained('/') PathPart('validate') Args(1) {
     return;
   }
 
-  my $validated_filename = 'validated_' . $file_hash->{filename};
-  my $validated_contents = $file_hash->{contents};
+  my $validated_filename  = 'validated_' . $file_hash->{filename};
+  my $compressed_contents = $file_hash->{contents};
+  my $validated_contents  = Compress::Zlib::memGunzip( $file_hash->{contents} );
 
   unless ( $validated_contents ) {
     $c->log->error("Didn't get validated file contents from cache");


### PR DESCRIPTION
When a file has been validated in the online validation tool, we cache the validated file, rather than storing it on disk. The default cache is memcached.

There was a problem with large CSV files, especially after adding a large number of error messages, in that the file size exceeded the default maximum item size for memcached. We should definitely increase
that limit but in the meantime it also makes sense to compress the stuff that we cache.

This commit adds a few lines that compress the validated file before caching it and uncompress it when retrieving it. The compression ratio for CSVs is pretty impressive, so that will buy us a lot of overhead and
shouldn't impact performance greatly.