### PR TITLE
A couple of UI tweaks

### DIFF
--- a/app/root/templates/pages/samples.tt
+++ b/app/root/templates/pages/samples.tt
@@ -62,7 +62,7 @@
             <th>Sample accession</th>
             <th>Donor ID</th>
             <th>Description</th>
-            <th>Collected at</th>
+            <th>Submitted by</th>
             <th>NCBI tax ID</th>
             <th>Scientific name (NCBI tax ID)</th>
             <th>Collected by</th>

--- a/app/root/templates/pages/summary.tt
+++ b/app/root/templates/pages/summary.tt
@@ -10,7 +10,8 @@
         [% summary.total_number_of_samples %]</a>
     </strong> samples from
     <strong>[% summary.total_number_of_manifests %]</strong> manifests.
-    You can <a href="[% c.uri_for('/samples', { dl => 1, 'content-type' => 'text/csv' } ) %]">
+    You can <a class="dl"
+      href="[% c.uri_for('/samples', { dl => 1, 'content-type' => 'text/csv' } ) %]">
       download all samples</a> in CSV format.
   </p>
 


### PR DESCRIPTION
Fix the column head in the samples table ("submitted by" now, not "collected at") and add an icon to a link in the summary page to show that it's a download.