### PR TITLE
Handle undefined fields when building samples table

### DIFF
--- a/app/root/static/javascripts/samples.js
+++ b/app/root/static/javascripts/samples.js
@@ -69,6 +69,7 @@ var samples = (function() {
             break;
           case null:
           case "":
+          case undefined:
             rv = "<span class='na'>n/a</span>";
             break;
           default:

--- a/app/root/templates/pages/samples.tt
+++ b/app/root/templates/pages/samples.tt
@@ -56,7 +56,7 @@
              class="table table-striped table-condensed table-bordered">
         <thead>
           <tr>
-            <th scope="row">Sample ID</th>
+            <th scope="row">MIDAS ID</th>
             <th>Manifest ID</th>
             <th>Raw data accession</th>
             <th>Sample accession</th>


### PR DESCRIPTION
When DataTables builds the HTML for the samples table, it uses a
renderer function that tweaks or formats the raw values from the server
before putting them into the table. Previously, if there was an
undefined value in the hash that came from the server (e.g.
location_description), the "switch" statement in the renderer would try
to put the value (undef) into the table directly, causing an alert from
DataTables.

This commit just adds a "case undefined", which makes the renderer treat
undefined values the same as empty strings, i.e. it replaces them by
"n/a" in the output.

Also, rename a column header in the samples table from "Sample ID" to
"MIDAS ID", to avoid confusion.