### PR TITLE
Only show "filtered by" in title when filtering

### DIFF
--- a/app/root/templates/pages/samples.tt
+++ b/app/root/templates/pages/samples.tt
@@ -24,7 +24,7 @@
       ELSIF susceptibility;
         " with $susceptibility AMR results";
         show_all = 1;
-      ELSIF format_params.filter_terms;
+      ELSIF format_params.filter_terms.size;
         ", filtered by '" _ format_params.filter_terms.join("', '") _ "'";
         show_all = 1;
       END -%]


### PR DESCRIPTION
Check if there are any filters applied to the results before putting the
"filtered by" clause in the page title.